### PR TITLE
Some adjustments to ctk_scrollable_dropdown.py

### DIFF
--- a/CTkScrollableDropdown/ctk_scrollable_dropdown.py
+++ b/CTkScrollableDropdown/ctk_scrollable_dropdown.py
@@ -46,6 +46,7 @@ class CTkScrollableDropdown(customtkinter.CTkToplevel):
             self.corner = 0
             self.padding = 18
             self.withdraw()
+            self.hide = True  # 
 
         self.hide = True
         self.attach.bind('<Configure>', lambda e: self._withdraw() if not self.disable else None, add="+")
@@ -149,7 +150,8 @@ class CTkScrollableDropdown(customtkinter.CTkToplevel):
         self.live_update(self.attach._entry.get())
         # Close dropdown if no text remains in the combobox entry section.
         if self.attach._entry.get() == "":
-            self.withdraw()       
+            self.withdraw()
+            self.hide = True  # Fix for an issue where the dropdown would close, but two clicks were required to open it again.   
     
     def bind_autocomplete(self):
         def appear(x):
@@ -223,7 +225,7 @@ class CTkScrollableDropdown(customtkinter.CTkToplevel):
                                            self.x_pos, self.y_pos))
         self.fade_in()
         self.attributes('-alpha', self.alpha)
-        self.attach.focus()
+        #self.attach.focus()
 
     def _iconify(self):
         if self.attach.cget("state")=="disabled": return
@@ -232,10 +234,10 @@ class CTkScrollableDropdown(customtkinter.CTkToplevel):
             self.hide = False
         if self.hide:
             self.event_generate("<<Opened>>")      
-            self.focus()
+            #self.focus()
             self.hide = False
 
-            # Reset dropdown to show all options regardless of entry text.
+            # Reset dropdown to show all options regardless of entry text when the dropdown button is manually pressed.
             for key in self.widgets.keys():
                 self.widgets[key].pack(fill="x", pady=2, padx=(self.padding, 0))
             self.button_num = len(self.values)

--- a/CTkScrollableDropdown/ctk_scrollable_dropdown.py
+++ b/CTkScrollableDropdown/ctk_scrollable_dropdown.py
@@ -46,7 +46,6 @@ class CTkScrollableDropdown(customtkinter.CTkToplevel):
             self.corner = 0
             self.padding = 18
             self.withdraw()
-            self.hide = True  # 
 
         self.hide = True
         self.attach.bind('<Configure>', lambda e: self._withdraw() if not self.disable else None, add="+")
@@ -281,7 +280,6 @@ class CTkScrollableDropdown(customtkinter.CTkToplevel):
                 self._deiconify()
                 self.button_num = visible_buttons
                 self.place_dropdown()
-                self.hide = False
             else:
                 self.withdraw()
                 self.hide = True

--- a/CTkScrollableDropdown/ctk_scrollable_dropdown.py
+++ b/CTkScrollableDropdown/ctk_scrollable_dropdown.py
@@ -5,7 +5,6 @@ Author: Akash Bora
 
 import customtkinter
 import sys
-import time
 import difflib
 
 class CTkScrollableDropdown(customtkinter.CTkToplevel):


### PR DESCRIPTION
**Some tweaks and improvements to the functionality and design of "ctk_scrollable_dropdown.py":**

1. Removed "time.sleep" in order to prevent typing delay in combo boxes, a different method may work better in the future to add a delay to the dropdown appearing without the program being paused completely.

2. When autocomplete is enabled and a string is typed into a combobox that doesn't match any strings in "values", there won't be any dropdown window that appears automatically. Previously, a dropdown would appear and state "No matches"; however, this doesn't seem to be necessary if a combobox is used similarly to an entry box and takes up screen real estate, potentially covering other elements in the window. This could still be useful if the use case requires the user to type a value that is the same as one of the values in the list, so this adjustment isn't crucial and could potentially become an argument instead.

3. When autocomplete is enabled and a string is typed into a combobox that doesn't match any strings in "values", though the automatic dropdown no longer appears, pressing the dropdown button manually will show all available strings in "values" rather than displaying "No matches", making it easier for users to choose between either their own typed values or the saved list values.

4. When using a specified background colour for the window/frame/canvas/etc behind the dropdown, there will be either a black or white pixelation (depending on CTk appearance mode) on the outer edge of the rounded corners of the dropdown, which becomes incredibly noticeable unless using the predefined background colour that comes with the Light and Dark appearance modes. This might be an issue specific to Windows, as I haven't tested on other platforms. Regardless, I have made a workaround by adding an argument for "bg_color", which works the same way as some other CTk widgets, where "bg_color" specifies the colour outside of the border, which you would see if the corners are rounded on some CTk widgets, such as buttons. If a color is specified for the "bg_color" argument, the pixelations will become that color, and this could be used by setting "bg_color" to the same color as any element that is behind the dropdown in order to make the pixelation blend in. If no color is specified, it will simply work like the original code which relies on the appearance mode.

5. Fixed the scaling of the dropdown window, as it originally had extra blank space beneath the lowest button. Also added functionality for the dropdown to resize when displaying autocomplete options, allocating space for just the visible buttons provided by autocomplete.

6. Fixed a bug where deleting the final character by pressing backspace, then trying to click off the dropdown would require two clicks. This has been fixed by simply withdrawing the dropdown when the combobox has an empty string (""). There was also an issue after this, where, after the dropdown was removed automatically, pressing the button for it would require two clicks. This has been solved by adding "self.hide = True" under the withdraw command.

I hope these adjustments will help!